### PR TITLE
Create fish config file for shell completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add tests for QA
 
+## [0.1.0-alpha.5] - 2023-08-02
+
+### Added
+
+- The fish configuration file for custom completions, ~/.config/fish/completions/{program_name}.fish
+(notice it's specific to the program name), is created if it doesn't already exist. ~/.bashrc and
+~/.zshrc configuration files, which are used to set up shell completion, are generic and we can assume
+the users have already created them.
+
 ## [0.1.0-alpha.4] - 2023-07-26
 
 ### Fixed

--- a/auto_click_auto/core.py
+++ b/auto_click_auto/core.py
@@ -6,7 +6,7 @@ from click import Command, Context, Parameter, option
 
 from .constants import ShellType
 from .exceptions import ShellEnvVarNotFoundError, ShellTypeNotSupportedError
-from .utils import add_shell_configuration, detect_shell
+from .utils import add_shell_configuration, create_file, detect_shell
 
 if TYPE_CHECKING:
     import typing_extensions as te
@@ -86,6 +86,12 @@ def enable_click_shell_completion(
             completer_script_path = os.path.expanduser(
                 f"~/.config/fish/completions/{program_name}.{shell}"
             )
+
+            # bash and zsh config files are generic, so we can assume the user
+            # already has created them. fish's shell configuration file for
+            # custom completions is specific to the program name, so we will
+            # create it if it doesn't already exist.
+            create_file(file_path=completer_script_path)
 
             # Completion implementation: `eval` command in shell configuration
             eval_command = (

--- a/auto_click_auto/utils.py
+++ b/auto_click_auto/utils.py
@@ -9,6 +9,27 @@ from auto_click_auto.exceptions import (
 )
 
 
+def create_file(file_path: str) -> None:
+    """
+    Check if the file and the directories of the given file path exist and if
+    not create them.
+
+    :param file_path: The path of the file the check and creation is done for.
+    :return: `None`
+    """
+
+    if not os.path.exists(file_path):
+        directory = os.path.dirname(file_path)
+
+        if not os.path.exists(directory):
+            # Recursive directory creation
+            os.makedirs(directory)
+
+        # Open for exclusive creation, failing if the file already exists
+        with open(file_path, 'x'):
+            pass
+
+
 def check_strings_in_file(file_path: str, search_strings: List[str]) -> bool:
     """
     Check if the given search strings are in the specified file.

--- a/auto_click_auto/utils.py
+++ b/auto_click_auto/utils.py
@@ -83,6 +83,16 @@ def add_shell_configuration(
 
 
 def detect_shell() -> ShellType:
+    """
+    Attempt to detect the shell type using the `SHELL` environment variable.
+
+    :raise ShellEnvVarNotFoundError: When the `SHELL` environment variable is
+    not set in the system.
+    :raise ShellTypeNotSupportedError: When the shell value returned from the
+    `SHELL` environment variable does not belong to one of the supported
+    shells.
+    """
+
     try:
         shell_env_var = os.environ["SHELL"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-click-auto"
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 description = "Automatically enable tab autocompletion for shells in Click CLI applications."
 authors = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]
 maintainers = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]


### PR DESCRIPTION
- The fish configuration file for custom completions, ~/.config/fish/completions/{program_name}.fish
(notice it's specific to the program name), is created if it doesn't already exist. ~/.bashrc and
~/.zshrc configuration files, which are used to set up shell completion, are generic and we can assume
the users have already created them.
- Update to version 0.1.0-alpha.5