### PR TITLE
Parametrize Python versions in functional tests

### DIFF
--- a/.github/workflows/functional-tests.yml
+++ b/.github/workflows/functional-tests.yml
@@ -7,9 +7,12 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
 
     - name: Run functional tests on Ubuntu environment
-      run: docker build . -f tests/functional/Dockerfile-ubuntu -t click-test-ubuntu
+      run: docker build . -f tests/functional/Dockerfile-ubuntu --build-arg PYTHON_VERSION=${{ matrix.python-version }} -t click-test-ubuntu

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2024-01-15
+
+### Fixed
+
+- Autocomplete did not work properly for Python 3.11 environments.
+Users can manually delete incorrectly created fish configuration file
+~/.config/fish/completions/{program_name}.ShellType.FISH, created from this
+bug (https://github.com/KAUTH/auto-click-auto/issues/9)
+
 ## [0.1.3] - 2023-12-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.1.4] - 2024-01-15
 
+### Added
+
+- Parametrized functional testing for Ubuntu environments for Python 3.9, 3.10, 3.11 (https://github.com/KAUTH/auto-click-auto/pull/10)
+
 ### Fixed
 
 - Autocomplete did not work properly for Python 3.11 environments.

--- a/auto_click_auto/core.py
+++ b/auto_click_auto/core.py
@@ -75,7 +75,7 @@ def enable_click_shell_completion(
     for shell in shells:
 
         if shell in (ShellType.BASH, ShellType.ZSH):
-            shell_config_file = os.path.expanduser(f"~/.{shell}rc")
+            shell_config_file = os.path.expanduser(f"~/.{shell.value}rc")
 
             # Completion implementation: `eval` command in shell configuration
             eval_command = (
@@ -105,7 +105,7 @@ def enable_click_shell_completion(
 
         elif shell == ShellType.FISH:
             completer_script_path = os.path.expanduser(
-                f"~/.config/fish/completions/{program_name}.{shell}"
+                f"~/.config/fish/completions/{program_name}.{shell.value}"
             )
 
             # bash and zsh config files are generic, so we can assume the user

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-click-auto"
-version = "0.1.3"
+version = "0.1.4"
 description = "Automatically enable tab autocompletion for shells in Click CLI applications."
 authors = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]
 maintainers = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]

--- a/tests/functional/Dockerfile-ubuntu
+++ b/tests/functional/Dockerfile-ubuntu
@@ -1,7 +1,9 @@
 # Dockerfile for functional testing of `auto-click-auto`
 
+ARG PYTHON_VERSION=3.10
+
 # Base test image to re-use for each test
-FROM python:3.10-slim-buster as base_test_env
+FROM python:${PYTHON_VERSION}-slim-buster as base_test_env
 
 RUN apt-get update && apt-get install -y vim zsh fish
 COPY . /opt/auto-click-auto/


### PR DESCRIPTION
- We parametrize the Python version used in the Dockerfile for the functional tests (using [build arguments](https://docs.docker.com/build/guide/build-args/)) so that we can test in Python 3.9, 3.10, and 3.11 Python versions.
- Fix Python 3.11 environments that were breaking and that we can now test with the above test improvements

Fixes #9