### PR TITLE
Handle `FileExistsError` when creating a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2] - 2023-12-17
+
+### Fixed
+
+- To avoid race conditions (e.g., when running parallel tests) we handle whether a file
+exists at the proper moment so that we don't crash when attempting to create configuration
+files that already exist (#11)
+
 ## [0.1.1] - 2023-08-31
 
 ### Fixed

--- a/auto_click_auto/utils.py
+++ b/auto_click_auto/utils.py
@@ -23,10 +23,16 @@ def create_file(file_path: str) -> None:
 
         if not os.path.exists(directory):
             # Recursive directory creation
-            os.makedirs(directory)
+            os.makedirs(directory, exist_ok=True)
 
-        # Open for exclusive creation, failing if the file already exists
-        with open(file_path, 'x'):
+        try:
+            # Open for exclusive creation
+            with open(file_path, 'x'):
+                pass
+
+        # To avoid race conditions we handle here as well whether the file
+        # exists.
+        except FileExistsError:
             pass
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-click-auto"
-version = "0.1.1"
+version = "0.1.2"
 description = "Automatically enable tab autocompletion for shells in Click CLI applications."
 authors = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]
 maintainers = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]


### PR DESCRIPTION
To avoid race conditions we handle the exception whether a file exists, even if we check already before checking for the directory existence.