### PR TITLE
Explicitly export functions

### DIFF
--- a/auto_click_auto/__init__.py
+++ b/auto_click_auto/__init__.py
@@ -1,4 +1,6 @@
 from .core import (
-    enable_click_shell_completion,
-    enable_click_shell_completion_option,
+    enable_click_shell_completion as enable_click_shell_completion,
+)
+from .core import (
+    enable_click_shell_completion_option as enable_click_shell_completion_option,
 )


### PR DESCRIPTION
Hey!

Got a small enhancement here, to comply with type checking tools requiring explicit exports of symbols.

## Background

I've come across a project that uses this package and trying to type-check using `mypy`, which fails as follows:

```
$ mypy --explicit-package-bases --ignore-missing-imports --strict .

error: Module "auto_click_auto" does not explicitly export attribute "enable_click_shell_completion"  [attr-defined]
```