### PR TITLE
Release v0.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.5] - 2024-06-26
+
+### Changed
+
+- Explicitly export `enable_click_shell_completion` and `enable_click_shell_completion_option`
+functions. This way, we comply with the "no-implicit-reexport" strictness in type checking
+when importing these functions (https://github.com/KAUTH/auto-click-auto/pull/14)
+Functionality has not changed.
+
 ## [0.1.4] - 2024-01-15
 
 ### Added

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,6 +1,6 @@
 [[package]]
 name = "click"
-version = "8.1.4"
+version = "8.1.7"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
@@ -106,8 +106,8 @@ content-hash = "5a034f7bd8678be82750bd49806647c3298265acaf76d36e8772ad5ff84bd328
 
 [metadata.files]
 click = [
-    {file = "click-8.1.4-py3-none-any.whl", hash = "sha256:2739815aaa5d2c986a88f1e9230c55e17f0caad3d958a5e13ad0797c166db9e3"},
-    {file = "click-8.1.4.tar.gz", hash = "sha256:b97d0c74955da062a7d4ef92fadb583806a585b2ea81958a81bd72726cbb8e37"},
+    {file = "click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28"},
+    {file = "click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de"},
 ]
 colorama = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "auto-click-auto"
-version = "0.1.4"
+version = "0.1.5"
 description = "Automatically enable tab autocompletion for shells in Click CLI applications."
 authors = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]
 maintainers = ["Konstantinos Papadopoulos <konpap1996@yahoo.com>"]

--- a/tests/functional/Dockerfile-ubuntu
+++ b/tests/functional/Dockerfile-ubuntu
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y vim zsh fish
 COPY . /opt/auto-click-auto/
 WORKDIR /opt/auto-click-auto
 
-RUN pip install -e .
+RUN pip install .
 
 # Test adding autocompletion for bash and fish
 FROM base_test_env as test_example_1


### PR DESCRIPTION
- Bump minor version after https://github.com/KAUTH/auto-click-auto/pull/14 typing enhancement
- Update requirements (this does not affect functionality)
- Use regular installs instead of editable ones in functional tests (see https://pip.pypa.io/en/stable/topics/local-project-installs/#regular-installs)
